### PR TITLE
Allow for multiple hooks.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+sudo: false
+language: node_js
+node_js:
+- 'iojs-2'
+- 'iojs-1'
+- '0.12'
+- '0.10'
+before_install:
+- npm install -g "npm@>=1.4.6"
+after_success:
+- npm install coveralls
+- cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Hook node module loading internals to do your bidding.
 
+![build status](http://img.shields.io/travis/izaakschroeder/hook-module/master.svg?style=flat&branch=master)
+![coverage](http://img.shields.io/coveralls/izaakschroeder/hook-module/master.svg?style=flat&branch=master)
+![license](http://img.shields.io/npm/l/hook-module.svg?style=flat)
+![version](http://img.shields.io/npm/v/hook-module.svg?style=flat)
+![downloads](http://img.shields.io/npm/dm/hook-module.svg?style=flat)
+
 You know those times when someone says "this is probably a terrible idea"? Yea. This is one of those. If you think you have a use case for this module you probably don't.
 
 Right now it's being used to load modules from webpack's in-memory filesystem, which would otherwise be impossible to do.

--- a/README.md
+++ b/README.md
@@ -2,26 +2,38 @@
 
 Hook node module loading internals to do your bidding.
 
-You know those times when someone says "this is probably a terrible idea"? Yea. This is one of those. If you think you have a use case for this module you probably don't. You have been warned.
+You know those times when someone says "this is probably a terrible idea"? Yea. This is one of those. If you think you have a use case for this module you probably don't.
 
 Right now it's being used to load modules from webpack's in-memory filesystem, which would otherwise be impossible to do.
 
 ```javascript
-var hook = require('hook-module');
+var hijack = require('hook-module');
 
-hook({
+var hook = hijack({
+	// Whether or not the hook starts enabled or not.
+	enabled: true,
 	// Test determines whether or not the hook is applied to a given module
 	// request. Pass true to hook everything, a regular expression or array
-	// of extensions or a function to hook only those matching.
+	// of extensions or a function to hook only those matching. Omit this
+	// to always apply your hook.
 	test: /\.(js|es6|es|jsx)$/,
 	// If you need a custom resolver pass it here. A function that takes as
-	// input (request, parent).
+	// input (request, parent). If omitted, just use node's default resolver.
 	resolve: null,
-	// Where the magic happens. Transform the module to your liking.
+	// Where the magic happens. Transform the module to your liking. when
+	// you are done, simply assign module.exports to the value you want the
+	// module to have.
 	handler: function(module, filename) {
-
+		module.exports = 'black magic';
 	}
-})
+});
+
+// Turn the hook off.
+hook.disable();
+
+// Turn the hook on.
+hook.enable();
 ```
+
 TODO:
- * [ ] Tests
+ * [ ] More tests

--- a/lib/hook.js
+++ b/lib/hook.js
@@ -6,6 +6,53 @@
 var path = require('path');
 var Module = module.constructor;
 
+var load = Module._load;
+var hooks = [ {
+	load: load,
+	enabled: true,
+	test: function() {
+		return true;
+	}
+} ];
+
+// Here we go.
+Module._load = function(request, parent) {
+	for (var i = 0; i < hooks.length; ++i) {
+		if (hooks[i].test.apply(null, arguments)) {
+			break;
+		}
+	}
+	return hooks[i].load.apply(hooks[i], arguments);
+}
+
+function normalizeTest(input) {
+	if (!input) {
+		return function() {
+			return true;
+		};
+	} else if (typeof input === 'function') {
+		return input;
+	} else if (input instanceof RegExp) {
+		return function(request) {
+			return input.test(request);
+		};
+	} else if (typeof input === 'string') {
+		return function(request) {
+			return request === input;
+		};
+	} else if (Array.isArray(input)) {
+		var tests = input.map(normalizeTest);
+		return function() {
+			var args = arguments;
+			return tests.some(function(test) {
+				return test.apply(null, args);
+			});
+		}
+	} else {
+		throw new TypeError('Invalid test.');
+	}
+}
+
 /**
  * Hook the module loading infrastructure of node. God help you if you ever
  * decide to use this for anything other than development and experimentation.
@@ -18,61 +65,78 @@ var Module = module.constructor;
  * @param {Array|RegExp|Function} options.test Resolves true to hook module.
  * @param {Function} options.handler Manipulate the module.
  * @param {Function} options.resolve Resolve initial module request.
- * @returns {Function} Function to remove the hook.
+ * @returns {Object} Resulting hook.
  */
-function hook(options) {
+function createHook(options) {
+
+	var test, resolve;
 
 	// Default to the node built-in resolver if none is provided.
-	if (!options.resolve) {
-		options.resolve = Module._resolveFilename;
-	}
+	resolve = options.resolve || Module._resolveFilename;
+	test = normalizeTest(options.test);
 
-	// Keep an old copy of the loader around.
-	var load = Module._load;
+	var hook = {
+		modules: { },
 
-	// Here we go.
-	Module._load = function loader(request, parent) {
+		test: test,
+		resolve: resolve,
 
-		// Check first to see if the hook should be applied; if not then just
-		// pass the request to the old loading code.
-		if (!options.test(request, parent)) {
-			return load.apply(Module, arguments);
-		}
-
-		// Resolve the filename from the module request
-		var filename = options.resolve(request, parent);
-
-		var cachedModule = Module._cache[filename];
-
-		if (cachedModule) {
-			return cachedModule.exports;
-		}
-
-		var module = new Module(filename, parent);
-		Module._cache[filename] = module;
-
-		var hadException = true;
-
-		try {
-			module.filename = filename;
-			module.paths = Module._nodeModulePaths(path.dirname(filename));
-			options.handler(module, filename);
-			module.loaded = true;
-			hadException = false;
-		} finally {
-			if (hadException) {
-				delete Module._cache[filename];
+		enable: function add() {
+			if (hooks.indexOf(this) === -1) {
+				hooks.unshift(this);
 			}
+		},
+
+		disable: function remove() {
+			var entry = hooks.indexOf(this);
+			for (var module in this.modules) {
+				delete Module._cache[module];
+				delete this.modules[module];
+			}
+			if (entry !== -1) {
+				hooks.splice(entry, 1);
+			}
+		},
+
+		load: function loader(request, parent) {
+
+			// Resolve the filename from the module request
+			var filename = options.resolve(request, parent);
+
+			var cachedModule = Module._cache[filename];
+
+			if (cachedModule) {
+				return cachedModule.exports;
+			}
+
+			var module = new Module(filename, parent);
+			this.modules[filename] = module;
+			Module._cache[filename] = module;
+
+			var hadException = true;
+
+			try {
+				module.filename = filename;
+				module.paths = Module._nodeModulePaths(path.dirname(filename));
+				options.handler(module, filename);
+				module.loaded = true;
+				hadException = false;
+			} finally {
+				if (hadException) {
+					delete Module._cache[filename];
+				}
+			}
+
+			return module.exports;
 		}
+	};
 
-		return module.exports;
+	if ((typeof options.enabled === 'undefined') || options.enabled) {
+		this.enable();
 	}
 
-	// Restore hook.
-	return function restore() {
-		Module._load = load;
-	}
+	return hook;
 }
 
 // Forgive us.
-module.exports = hook;
+module.exports = createHook;

--- a/package.json
+++ b/package.json
@@ -3,5 +3,12 @@
 	"version": "0.1.0",
 	"author": "Izaak Schroeder <izaak.schroeder@gmail.com>",
 	"main": "./lib/hook.js",
-	"license": "CC0-1.0"
+	"license": "CC0-1.0",
+	"scripts": {
+		"test": "./node_modules/.bin/mocha test/spec/*.js"
+	},
+	"devDependencies": {
+		"mocha": "^2.2.5",
+		"chai": "^3.0.0"
+	}
 }

--- a/test/spec/hook.spec.js
+++ b/test/spec/hook.spec.js
@@ -1,0 +1,90 @@
+
+var expect = require('chai').expect;
+var hijack = require('../../lib/hook');
+
+describe('hook', function() {
+
+	describe('single hooks', function() {
+		var hook = hijack({
+			enabled: false,
+			test: function(request) {
+				return request === '!foo';
+			},
+			resolve: function(request) {
+				return '/some/magic/file.js';
+			},
+			handler: function(module) {
+				module.exports = 'Hello World';
+			}
+		});
+
+		beforeEach(function() {
+			hook.enable();
+		});
+
+		afterEach(function() {
+			hook.disable();
+		});
+
+		it('should only hook when test is true', function() {
+			expect(require('!foo')).to.equal('Hello World');
+			expect(function() {
+				require('!bar');
+			}).to.throw(Error);
+		});
+
+		it('should only hook when enabled', function() {
+			hook.disable();
+			expect(function() {
+				require('!foo');
+			}).to.throw(Error);
+		});
+	});
+
+	describe('multiple hooks', function() {
+		var a = hijack({
+			enabled: false,
+			test: function(request) {
+				return request === '!foo';
+			},
+			resolve: function(request) {
+				return '/some/magic/file.js';
+			},
+			handler: function(module) {
+				module.exports = 'foo';
+			}
+		}), b = hijack({
+			enabled: false,
+			test: function(request) {
+				return request === '!foo';
+			},
+			resolve: function(request) {
+				return '/some/other/file.js';
+			},
+			handler: function(module) {
+				module.exports = 'bar';
+			}
+		});
+
+		beforeEach(function() {
+			a.enable();
+			b.enable();
+		});
+
+		afterEach(function() {
+			b.disable();
+			a.disable();
+		});
+
+		it('should use the most recent hook first', function() {
+			expect(require('!foo')).to.equal('bar');
+		});
+
+		it('should respect disabled hooks', function() {
+			expect(require('!foo')).to.equal('bar');
+			b.disable();
+			expect(require('!foo')).to.equal('foo');
+		});
+	});
+
+});


### PR DESCRIPTION
Now you can install a bunch of different hooks and then add/remove them by calling `.enable` and `.disable`. Hooks are automatically enabled by default, unless `enable: false` is passed in as part of the options. Due to this we now also have some primitive tests.
