### PR TITLE
Use hook resolve instead of options.

### DIFF
--- a/lib/hook.js
+++ b/lib/hook.js
@@ -101,7 +101,7 @@ function createHook(options) {
 		load: function loader(request, parent) {
 
 			// Resolve the filename from the module request
-			var filename = options.resolve(request, parent);
+			var filename = this.resolve(request, parent);
 
 			var cachedModule = Module._cache[filename];
 


### PR DESCRIPTION
Since the hook resolve can be assigned to the default node loader one if no options resolve is provided.
